### PR TITLE
Add SSD cache simulator web app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>SSD Cache Simulator</title>
+<link rel="stylesheet" href="style.css">
+<script src="https://cdn.jsdelivr.net/npm/p5@1.4.0/lib/p5.min.js"></script>
+</head>
+<body>
+<div class="container">
+  <h1>SSD Cache Simulator</h1>
+  <div class="controls">
+    <label>Test Pattern
+      <select id="pattern">
+        <option value="seqRead">Sequential Read</option>
+        <option value="randRead">Random Read</option>
+        <option value="seqWrite">Sequential Write</option>
+        <option value="randWrite">Random Write</option>
+      </select>
+    </label>
+    <label>Cmd Size
+      <select id="cmdSize">
+        <option value="4">4KB</option>
+        <option value="8">8KB</option>
+        <option value="16">16KB</option>
+        <option value="32">32KB</option>
+        <option value="64">64KB</option>
+        <option value="128">128KB</option>
+      </select>
+    </label>
+    <label>Commands
+      <input type="number" id="cmdNum" value="10000" min="1">
+    </label>
+    <label>LCA Range
+      <input type="number" id="lcaRange" value="1000" min="1">
+    </label>
+    <label>Cache Num
+      <input type="number" id="cacheNum" value="1024" min="1">
+    </label>
+    <label>Bucket Num
+      <input type="number" id="bucketNum" value="128" min="1">
+    </label>
+    <label>Buffer Num
+      <input type="number" id="bufferNum" value="64" min="1">
+    </label>
+    <label>Nand Read Time (ms)
+      <input type="number" id="nandRead" value="20" min="0">
+    </label>
+    <label>Nand Program Time (ms)
+      <input type="number" id="nandProg" value="50" min="0">
+    </label>
+    <label>Nand Program Count (4KB)
+      <input type="number" id="progCnt" value="4" min="1">
+    </label>
+    <label>Queue Depth
+      <input type="number" id="queueDepth" value="32" min="1">
+    </label>
+    <button id="startBtn">Start Pattern</button>
+  </div>
+  <div id="status" class="status"></div>
+  <div id="visualization"></div>
+  <div id="result" class="result"></div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,179 @@
+class CacheNode {
+  constructor() {
+    this.lca = -1;
+    this.ready = false;
+  }
+}
+
+class CacheSim {
+  constructor(params) {
+    this.params = params;
+    this.cacheNum = params.cacheNum;
+    this.bucketNum = params.bucketNum;
+    this.nodes = new Array(this.cacheNum).fill(0).map(() => new CacheNode());
+    this.buckets = new Array(this.bucketNum).fill(0).map(() => []);
+    this.freeList = [];
+    for (let i = 0; i < this.cacheNum; i++) this.freeList.push(i);
+    this.lru = [];
+    this.hit = 0;
+    this.miss = 0;
+  }
+
+  hash(lca) {
+    // simple hash
+    return (lca * 2654435761) >>> 0;
+  }
+
+  getBucket(lca) {
+    return this.hash(lca) % this.bucketNum;
+  }
+
+  moveToRecent(idx) {
+    const pos = this.lru.indexOf(idx);
+    if (pos !== -1) this.lru.splice(pos, 1);
+    this.lru.push(idx);
+  }
+
+  evictLRU() {
+    const idx = this.lru.shift();
+    if (idx === undefined) return null;
+    const node = this.nodes[idx];
+    if (node.lca !== -1) {
+      const b = this.getBucket(node.lca);
+      const arr = this.buckets[b];
+      const p = arr.indexOf(idx);
+      if (p !== -1) arr.splice(p, 1);
+    }
+    node.lca = -1;
+    node.ready = false;
+    this.freeList.push(idx);
+    return idx;
+  }
+
+  getNode(lca) {
+    const b = this.getBucket(lca);
+    const arr = this.buckets[b];
+    for (let i = 0; i < arr.length; i++) {
+      const idx = arr[i];
+      if (this.nodes[idx].lca === lca) return idx;
+    }
+    return null;
+  }
+
+  allocateNode(lca) {
+    let idx = this.freeList.pop();
+    if (idx === undefined) {
+      idx = this.evictLRU();
+    }
+    const node = this.nodes[idx];
+    node.lca = lca;
+    node.ready = true;
+    this.moveToRecent(idx);
+    const b = this.getBucket(lca);
+    this.buckets[b].push(idx);
+    return idx;
+  }
+
+  read(lca) {
+    const idx = this.getNode(lca);
+    if (idx !== null) {
+      this.hit++;
+      this.moveToRecent(idx);
+    } else {
+      this.miss++;
+      this.allocateNode(lca);
+    }
+  }
+
+  write(lca) {
+    const idx = this.getNode(lca);
+    if (idx !== null) {
+      // evict existing
+      const b = this.getBucket(lca);
+      const arr = this.buckets[b];
+      const p = arr.indexOf(idx);
+      if (p !== -1) arr.splice(p, 1);
+      const pos = this.lru.indexOf(idx);
+      if (pos !== -1) this.lru.splice(pos, 1);
+      this.freeList.push(idx);
+    }
+    this.allocateNode(lca);
+  }
+}
+
+function getParams() {
+  return {
+    pattern: document.getElementById('pattern').value,
+    cmdSize: parseInt(document.getElementById('cmdSize').value),
+    cmdNum: parseInt(document.getElementById('cmdNum').value),
+    lcaRange: parseInt(document.getElementById('lcaRange').value),
+    cacheNum: parseInt(document.getElementById('cacheNum').value),
+    bucketNum: parseInt(document.getElementById('bucketNum').value),
+    bufferNum: parseInt(document.getElementById('bufferNum').value),
+    nandRead: parseInt(document.getElementById('nandRead').value),
+    nandProg: parseInt(document.getElementById('nandProg').value),
+    progCnt: parseInt(document.getElementById('progCnt').value),
+    queueDepth: parseInt(document.getElementById('queueDepth').value)
+  };
+}
+
+function randomLCA(range) {
+  return Math.floor(Math.random() * range);
+}
+
+function runPattern() {
+  const params = getParams();
+  const sim = new CacheSim(params);
+  let lca = 0;
+  for (let i = 0; i < params.cmdNum; i++) {
+    let cmdLCA;
+    if (params.pattern === 'seqRead' || params.pattern === 'seqWrite') {
+      cmdLCA = lca;
+      lca += params.cmdSize;
+      if (lca >= params.lcaRange) lca = 0;
+    } else {
+      cmdLCA = randomLCA(params.lcaRange);
+    }
+    if (params.pattern === 'seqRead' || params.pattern === 'randRead') {
+      sim.read(cmdLCA);
+    } else {
+      sim.write(cmdLCA);
+    }
+  }
+  const hitRate = sim.hit / params.cmdNum;
+  const missRate = sim.miss / params.cmdNum;
+  document.getElementById('result').textContent =
+    `Hit Rate: ${(hitRate*100).toFixed(2)}%  Miss Rate: ${(missRate*100).toFixed(2)}%`;
+}
+
+function setupUI() {
+  const btn = document.getElementById('startBtn');
+  btn.addEventListener('click', () => {
+    document.getElementById('result').textContent = '';
+    document.getElementById('status').innerHTML = '<div class="spinner"></div>';
+    setTimeout(() => {
+      runPattern();
+      document.getElementById('status').innerHTML = '';
+    }, 50);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', setupUI);
+
+let simCanvas;
+function setup() {
+  simCanvas = createCanvas(760, 200);
+  simCanvas.parent('visualization');
+}
+
+function draw() {
+  background(240);
+  fill('#3498db');
+  noStroke();
+  const params = getParams();
+  const count = params.cacheNum;
+  const size = width / count;
+  for (let i = 0; i < count; i++) {
+    rect(i * size, 50, size - 1, 50);
+  }
+}

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,48 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f4f4f4;
+  margin: 0;
+  padding: 0;
+}
+.container {
+  max-width: 800px;
+  margin: auto;
+  padding: 20px;
+}
+.controls label {
+  display: block;
+  margin: 10px 0;
+}
+.controls select, .controls input {
+  margin-left: 10px;
+}
+#startBtn {
+  padding: 10px 20px;
+  margin-top: 10px;
+}
+.status {
+  margin-top: 20px;
+  font-size: 18px;
+}
+.result {
+  margin-top: 20px;
+  font-size: 20px;
+  font-weight: bold;
+}
+#visualization {
+  margin-top: 20px;
+  border: 1px solid #ccc;
+}
+.spinner {
+  border: 6px solid #f3f3f3;
+  border-top: 6px solid #3498db;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin: 20px auto;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- add web-based cache simulator using HTML/CSS/JavaScript
- visualize using p5.js with simple control panel

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853d53b02a883328a0eaad2ceebca88